### PR TITLE
Bug fix: headers discarded when value contains one or more colon chars

### DIFF
--- a/hal_browser.js
+++ b/hal_browser.js
@@ -306,9 +306,9 @@
       var headers = {};
       _.each(header_lines, function(line) {
         var parts = line.split(':');
-        if (parts.length == 2) {
-          var name = parts[0].trim();
-          var value = parts[1].trim();
+        if (parts.length > 1) {
+          var name = parts.shift().trim();
+          var value = parts.join(':').trim();
           headers[name] = value;
         }
       });


### PR DESCRIPTION
fyi: I discovered the problem while trying to figure out why the "If-Unmodified-Since" headers I was inputting weren't showing up server-side.  The values are datestamps (like "Thu, 22 Nov 2012 22:45:25 GMT").
