### PR TITLE
[WIP] Add JSONP support, for external APIs browsing

### DIFF
--- a/hal_browser.js
+++ b/hal_browser.js
@@ -10,14 +10,15 @@
     this.vent = opts.vent;
     this.headers = HAL.parseHeaders($('#request-headers').val());
     this.get = function(url) {
+      var p = url[0] !== '/' ? 'p' : '';
       var self = this;
       this.vent.trigger('location-change', { url: url });
       var jqxhr = $.ajax({
         url: url,
-        dataType: 'json',
+        dataType: 'json' + p,
         headers: this.headers,
         success: function(resource, textStatus, jqXHR) {
-          self.vent.trigger('response', { 
+          self.vent.trigger('response', {
             resource: resource,
             headers: jqXHR.getAllResponseHeaders()
           });


### PR DESCRIPTION
Allow user to use JSONP to fetch non-same domain APIs.

This way, one can host the hal_browser anywhere and does not have to add to modify his or her API server.

My 2 cents.
