### PR TITLE
Parsing error when "curie" is an array

### DIFF
--- a/hal_browser.js
+++ b/hal_browser.js
@@ -401,8 +401,20 @@
 
   HAL.buildUrl = function(rel) {
     if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curie) {
-      var tmpl = uritemplate(HAL.currentDocument._links.curie.href);
-      return tmpl.expand({ rel: rel.split(':')[1] });
+      var parts = rel.split(':');
+      var curie = HAL.currentDocument._links.curie;
+      if (curie instanceof Array) {
+        for (var i=0; i<curie.length; i++) {
+          if (curie[i].name == parts[0]) {
+            var href = curie[i].href
+          }
+        }
+      }
+      else {
+        var href = curie.href;
+      }
+      var tmpl = uritemplate(href);
+      return tmpl.expand({ rel: parts[1] });
     } else {
       return rel;
     }


### PR DESCRIPTION
In the spec, there is an example where "curie" is set to an array of objects. However, it doesn't seem the HAL browser can handle an array of curies.

This commit simply tests whether "curie" is an array, and if it is iterates through the array until it finds a "name" property which matches the prefix. I'm not familiar enough with the code to tell if this is the most elegant way, but it works.
