### PR TITLE
Update CURIE handling to draft-kelly-json-hal-04

### DIFF
--- a/hal_browser.js
+++ b/hal_browser.js
@@ -400,10 +400,23 @@
   };
 
   HAL.buildUrl = function(rel) {
-    if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curie) {
+    if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curies) {
+      var parts = rel.split(':');
+      var curies = HAL.currentDocument._links.curies;
+      for (var i=0; i<curies.length; i++) {
+        if (curies[i].name == parts[0]) {
+          var tmpl = uritemplate(curies[i].href);
+          return tmpl.expand({ rel: parts[1] });
+        }
+      }
+    }
+    // Backward compatible with <04 version of spec.
+    else if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curie) {
       var tmpl = uritemplate(HAL.currentDocument._links.curie.href);
       return tmpl.expand({ rel: rel.split(':')[1] });
-    } else {
+    }
+    // End BC.
+    else {
       return rel;
     }
   };


### PR DESCRIPTION
In draft-kelly-json-hal-04, the "curie" property was changed to "curies". Currently, the buildUrl function expects "curie".
