### PR TITLE
Fixed issue 13

### DIFF
--- a/hal_browser.html
+++ b/hal_browser.html
@@ -70,7 +70,7 @@
       <p>URI Template:</p>
       <pre><%= href %></pre>
       <p>Input (JSON):</p>
-      <textarea style="width: 100%; height: 300px">{ "foo": "bar" }</textarea>
+      <textarea style="width: 100%; height: 300px"><%= input %></textarea>
       <p>Expanded URI:</p>
       <pre class="preview">&nbsp;</pre>
       <input type="submit" value="Follow URI" />

--- a/hal_browser.js
+++ b/hal_browser.js
@@ -327,8 +327,29 @@
       this.$('.preview').html(result);
     },
 
+    extractExpressionNames: function (template) {
+      var names = [];
+      for (var i=0; i<template.set.length; i++) {
+        if (template.set[i].vars) {
+          for (var j=0; j<template.set[i].vars.length; j++) {
+            names.push(template.set[i].vars[j].name);
+          }
+        }
+      }
+      return names;
+    },
+
+    createDefaultInput: function (expressionNames) {
+      var defaultInput = {};
+      for (var i=0; i<expressionNames.length; i++) {
+        defaultInput[expressionNames[i]] = '';
+      }
+      return JSON.stringify(defaultInput, null, HAL.jsonIndent);
+    },
+
     render: function() {
-      this.$el.html(this.template({ href: this.href }));
+      var input = this.createDefaultInput(this.extractExpressionNames(this.uriTemplate));
+      this.$el.html(this.template({ href: this.href, input: input }));
       this.$('textarea').trigger('keyup');
       return this;
     },


### PR DESCRIPTION
Issue: https://github.com/mikekelly/hal-browser/issues/13

The dialog that appear when trying to GET a templated URI is now prepopulated
with JSON that contains the expressions available in the URI template.

It contains all expressions regardless whether they are optional or mandatory.

The implementation is tightly coupled with the current implementation of
uritemplate.js.

![uri-template-dialog](https://f.cloud.github.com/assets/137649/209907/b2ea4a78-827f-11e2-94a5-606ffd548351.png)
