### PR TITLE
Fixed support for curies where there is only one curie.

### DIFF
--- a/js/hal.js
+++ b/js/hal.js
@@ -22,10 +22,15 @@
       if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curies) {
         var parts = rel.split(':');
         var curies = HAL.currentDocument._links.curies;
-        for (var i=0; i<curies.length; i++) {
-          if (curies[i].name == parts[0]) {
-            var tmpl = uritemplate(curies[i].href);
-            return tmpl.expand({ rel: parts[1] });
+        if (!$.isArray(curies)) {
+          var tmpl = uritemplate(HAL.currentDocument._links.curies.href);
+          return tmpl.expand({ rel: rel.split(':')[1] });
+        } else {
+          for (var i=0; i<curies.length; i++) {
+            if (curies[i].name == parts[0]) {
+              var tmpl = uritemplate(curies[i].href);
+              return tmpl.expand({ rel: parts[1] });
+            }
           }
         }
       }


### PR DESCRIPTION
Draft 5 claims that

> The CURIE Syntax [W3C.NOTE-curie-20101216] MAY be used for brevity
>    for these URIs.  CURIEs are established within a HAL document via a
>    set of Link Objects with the relation type "curies" on the root
>    Resource Object.  These links contain a URI Template with the token
>    'rel', and are named via the "name" property.

My interpretation was that this is standard hal - if there is one curie, have a single object, if there are many, have an array. Currently, hal-browser only works if there is either one curie called 'curie' (draft < 4, for backwards compatibility), or multiple curies called 'curies'. This fixes that bug.
