### PR TITLE
Fixed javascript error when 'content-type' header hasn't been set.

### DIFF
--- a/js/hal/views/response_body.js
+++ b/js/hal/views/response_body.js
@@ -22,7 +22,9 @@ HAL.Views.ResponseBody = Backbone.View.extend({
       // interesting response body (possibly JSON) to show.
       var content_type = e.jqxhr.getResponseHeader('content-type');
       var responseText = e.jqxhr.responseText;
-      if(content_type.indexOf('json') != -1) {
+      if(content_type == null || content_type.indexOf('text/') == 0) {
+        output = responseText;
+      } else if(content_type.indexOf('json') != -1) {
         // Looks like json... try to parse it.
         try {
           var obj = JSON.parse(responseText);
@@ -31,8 +33,6 @@ HAL.Views.ResponseBody = Backbone.View.extend({
           // JSON parse failed. Just show the raw text.
           output = responseText;
         }
-      } else if(content_type.indexOf('text/') == 0) {
-        output = responseText;
       }
     }
     return output


### PR DESCRIPTION
The jQuery AJAX method sometimes returns a error response with an empty body and a status code of 0. This only really occurs when the url is unreachable but the hal-browser javascript currently crashes as it expects all responses to have the 'content-type' header set.

This change simple handles responses without a 'Content-Type' a little better and displays the response body on the page rather than showing nothing at all.
