### PR TITLE
Fix bug where customer request headers are backwards in non-get modal

### DIFF
--- a/js/hal/views/non_safe_request_dialog.js
+++ b/js/hal/views/non_safe_request_dialog.js
@@ -41,7 +41,7 @@ HAL.Views.NonSafeRequestDialog = Backbone.View.extend({
     var headers = HAL.client.getDefaultHeaders(),
         headersString = '';
 
-    _.each(headers, function(name, value) {
+    _.each(headers, function(value, name) {
       headersString += name + ': ' + value + '\n';
     });
 


### PR DESCRIPTION
When doing a non-get request, the name/value pairs for customer request headers are backwards in the modal that pops up. This can be duplicated in the HAL Talk application by doing the following:
1. Go to http://haltalk.herokuapp.com/explorer/browser.html#/
2. Type in a customer request header (I just typed Name: Value)
3. Click on a non-get button (I just selected ht:users)

Once the modal pops up, you should see `Value: Name` instead of `Name: Value`. This comes down to how those headers are built from in the render function for this view. The `each` function for underscore seems to want the value first and then the name rather than the other way around. 

This pull request simply flips name and value in that iterator sent to `each`. 
