### PR TITLE
Parse and render error response content rather than just the headers. 

### DIFF
--- a/js/hal/views/resource.js
+++ b/js/hal/views/resource.js
@@ -9,7 +9,12 @@ HAL.Views.Resource = Backbone.View.extend({
     });
 
     this.vent.bind('fail-response', function(e) {
-      self.vent.trigger('response', { resource: null, jqxhr: e.jqxhr });
+        try {
+            resource = JSON.parse(e.jqxhr.responseText);
+        } catch(err) {
+            resource = null;
+        }
+        self.vent.trigger('response', { resource: resource, jqxhr: e.jqxhr });
     });
   },
 


### PR DESCRIPTION
I've updated the error response handler so that it tries to parse the response body as JSON rather than just assuming there is no response body. It it fails to parse the response body as JSON it will fall back to the original behaviour.

This is useful when the response has an error status code (500) but still contains valid hal+json content.
