### PR TITLE
Clean up empty query params before interpolating URI templates

### DIFF
--- a/js/hal/views/query_uri_dialog.js
+++ b/js/hal/views/query_uri_dialog.js
@@ -68,7 +68,7 @@ HAL.Views.QueryUriDialog = Backbone.View.extend({
   cleanInput: function(inputObj) {
     var obj = {}
     for(var k in inputObj) {
-      if(inputObj.hasOwnProperty(k) && inputObj[k] != null && inputObj[k] != '') {
+      if(inputObj.hasOwnProperty(k) && inputObj[k] != null && String(inputObj[k]).trim() != '') {
         obj[k] = inputObj[k]
       }
     }


### PR DESCRIPTION
## What

This removes keys with empty values from input objects before interpolating them into templated URIs.

Otherwise an input like this:

``` javascript
{
  "foo": 1,
  "bar": ""
}
```

.. Get's mapped to a URI like this:

```
host.com?foo=1&bar=
```

With this change, the case above results in 

```
host.com?foo=1
```

`null` or empty string fields will be ignored. Not sure this is desirable for all cases but it makes sense as a rule of thumb.

![screenshot 2014-05-02 18 51 57](https://cloud.githubusercontent.com/assets/1081/2865931/e127efdc-d222-11e3-9af2-dcce90b687c7.png)
## Why

The same can be achieved by editing the input object manually in the provided text-area and removing the unwanted properties, but that gets annoying when there are too many optional properties.
