### PR TITLE
Prevent error when document does not cotain _links

### DIFF
--- a/js/hal.js
+++ b/js/hal.js
@@ -19,6 +19,9 @@
         return str.replace(replaceRegex, '.../');
     },
     buildUrl: function(rel) {
+      if (!HAL.currentDocument._links) {
+        return rel;
+      }
       if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curies) {
         var parts = rel.split(':');
         var curies = HAL.currentDocument._links.curies;


### PR DESCRIPTION
According to the spec 

```
{}
```

is a valid document, but when fed a doc without a `_link` element the browser chokes. Not sure if this is the best way to fix it but it worked for https://github.com/plexus/yakports 
