### PR TITLE
Display titles of embedded resources even when accordian is collapsed

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -191,7 +191,7 @@ Content-Type: application/json
 
   <script id="embedded-resource-template" type="text/template">
     <div class="accordion-heading">
-      <a class="accordion-toggle" href="#"><%= resource.identifier %>
+      <a class="accordion-toggle" href="#"><%= resource.identifier %><% console.log(resource); if (resource.title) { %>: <span class="embedded-resource-title"><%- resource.title %></span><% } %>
       <% if (HAL.isUrl(resource.embed_rel)) { %>
         <span class="dox pull-right" data-href="<%= HAL.buildUrl(resource.embed_rel) %>">
           <i class="icon-book"></i>

--- a/js/hal/resource.js
+++ b/js/hal/resource.js
@@ -2,6 +2,7 @@ HAL.Models.Resource = Backbone.Model.extend({
   initialize: function(representation) {
     representation = representation || {};
     this.links = representation._links;
+    this.title = representation.title;
     if(representation._embedded !== undefined) {
       this.embeddedResources = this.buildEmbeddedResources(representation._embedded);
     }

--- a/styles.css
+++ b/styles.css
@@ -65,3 +65,12 @@ body table.table {
 .ajax-loader.visible {
   opacity: 1;
 }
+.embedded-resource-title {
+  font-style: italic;
+}
+.embedded-resource-title:before {
+  content: "\"";
+}
+.embedded-resource-title:after {
+  content: "\"";
+}


### PR DESCRIPTION
This simply shows the titles of embedded resources, making it easier to scan through the list for something without having to expand each one.
