### PR TITLE
Force docs (curies) to be downloaded as JSON.

### DIFF
--- a/js/hal/views/documentation.js
+++ b/js/hal/views/documentation.js
@@ -2,6 +2,15 @@ HAL.Views.Documenation = Backbone.View.extend({
   className: 'documentation',
 
   render: function(url) {
-    this.$el.html('<iframe src=' + url + '></iframe>');
+    this.$el.html('<pre id="docSection">Loading...</pre>');
+    $.ajax({
+      url: url,
+      dataType: 'json',
+      success: function(resource) {
+        $('#docSection').text(JSON.stringify(resource, null, '  '));
+      }
+    }).error(function() {
+      $('#docSection').text('Error: Unable to get documentation');
+    });
   }
 });


### PR DESCRIPTION
When using *iframe* there is no control over HTTP headers. If REST service returns data in several formats then ```application/xml``` is preferred over ```application/json``` by all major browsers. Simple solution to that problem is to use *ajax* instead of *iframe*. That is what I implemented in this pull request and would be great if you would like to merge it into your main repository :)