### PR TITLE
Fix for : documentation iframe does not scale to 100% height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,5 @@
+html, body, #browser, .hal-browser { height: 100%; }
+
 #browser #location-bar { margin: 10px 0; }
 
 #browser #location-bar .address {


### PR DESCRIPTION
When you click on a documentation link in the halbrowser it opens this documentation in an iframe in the right hand column. 

On recent versions of safari / firefox / chrome on the mac this iframe is not scaled to 100% height despite the following css being applied to it

    .documentation iframe { width: 100%; height: 100%; }

This css will work in quirks mode but, the hal browser uses an html5 doc type, so here it does not.
The default height of an element is auto and you can't take a percentage from that  

Example of what it looks like now :

![screen shot 2015-01-01 at 18 22 25](https://cloud.githubusercontent.com/assets/133639/5592786/3f7e0690-91e3-11e4-87fe-8c8b610fe957.png)