### PR TITLE
Made Location and Content-Location header values navigatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ All the JS and CSS dependencies come included in the vendor directory.
 
 TODO
 ===========
-* Make Location and Content-Location headers clickable links
 * Provide feedback to user when there are issues with response (missing
 self link, wrong media type identifier)
 * Give 'self' and 'curies' links special treatment

--- a/browser.html
+++ b/browser.html
@@ -123,7 +123,16 @@
     <h2>Response Headers</h2>
     <pre><%= status.code %> <%= status.text %>
 
-<%= _.escape(headers) %></pre>
+<% _.each(headers, function(value, name) {
+      %><%= _.escape(name) %>: <%
+           if(HAL.isFollowableHeader(name)) {
+           %><a href="<%= _.escape(value) %>" class="follow"><%
+           }
+      %><%= _.escape(value)
+      %><% if(HAL.isFollowableHeader(name)) {
+           %></a><%
+           } %>
+<% }) %></pre>
   </script>
 
   <script id="response-body-template" type="text/template">

--- a/js/hal.js
+++ b/js/hal.js
@@ -14,6 +14,9 @@
     isUrl: function(str) {
       return str.match(urlRegex) || isCurie(str);
     },
+    isFollowableHeader: function(headerName) {
+      return headerName === 'Location' || headerName === 'Content-Location';
+    },
     truncateIfUrl: function(str) {
       var replaceRegex = /(http|https):\/\/([^\/]*)\//;
         return str.replace(replaceRegex, '.../');

--- a/js/hal/views/response_headers.js
+++ b/js/hal/views/response_headers.js
@@ -3,7 +3,18 @@ HAL.Views.ResponseHeaders = Backbone.View.extend({
     this.vent = opts.vent;
   },
 
+  events: {
+    'click .follow': 'followLink'
+  },
+
   className: 'response-headers',
+
+  followLink: function(e) {
+    e.preventDefault();
+    var $target = $(e.currentTarget);
+    var uri = $target.attr('href');
+    window.location.hash = uri;
+  },
 
   render: function(e) {
     this.$el.html(this.template({
@@ -11,7 +22,7 @@ HAL.Views.ResponseHeaders = Backbone.View.extend({
         code: e.jqxhr.status,
         text: e.jqxhr.statusText
       },
-      headers: e.jqxhr.getAllResponseHeaders()
+      headers: HAL.parseHeaders(e.jqxhr.getAllResponseHeaders())
     }));
   },
 


### PR DESCRIPTION
Straightforward patch that makes the urls returned in the Location Content-Location headers navigatable

This was actually mentioned as one of the TODO items in the halbrowser readme file