### PR TITLE
Escape url in query uri dialogues

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -149,7 +149,7 @@
     <form id="query" action="<%= href %>">
       <div class="modal-body">
         <p>URI Template:</p>
-        <pre><%= href %></pre>
+        <pre><%- href %></pre>
         <p>Input (JSON):</p>
         <textarea><%= input %></textarea>
         <p>Expanded URI:</p>

--- a/js/hal/views/query_uri_dialog.js
+++ b/js/hal/views/query_uri_dialog.js
@@ -34,7 +34,7 @@ HAL.Views.QueryUriDialog = Backbone.View.extend({
     } catch (err) {
       result = 'Invalid json input';
     }
-    this.$('.preview').html(result);
+    this.$('.preview').text(result);
   },
 
   extractExpressionNames: function (template) {


### PR DESCRIPTION
If a url contains something such as &curren in it (e.g /abc?a=1&current_value=50) then the url is displayed with a symbol in place of the text &curren because the url is not escaped

/abc?a=1¤t_value=50

This is displayed in both URI Template and Expanded URI boxes

Pull request fixes this