### PR TITLE
Fix for $.ajaxSetup not working in Chrome. Usage is not recommended.

### DIFF
--- a/js/hal/http/client.js
+++ b/js/hal/http/client.js
@@ -1,6 +1,6 @@
 HAL.Http.Client = function(opts) {
   this.vent = opts.vent;
-  $.ajaxSetup({ headers: { 'Accept': 'application/hal+json, application/json, */*; q=0.01' } });
+  this.defaultHeaders = { 'Accept': 'application/hal+json, application/json, */*; q=0.01' };
 };
 
 HAL.Http.Client.prototype.get = function(url) {
@@ -9,6 +9,7 @@ HAL.Http.Client.prototype.get = function(url) {
   var jqxhr = $.ajax({
     url: url,
     dataType: 'json',
+    headers: this.defaultHeaders,
     success: function(resource, textStatus, jqXHR) {
       self.vent.trigger('response', {
         resource: resource,
@@ -30,7 +31,6 @@ HAL.Http.Client.prototype.request = function(opts) {
 
 HAL.Http.Client.prototype.updateDefaultHeaders = function(headers) {
   this.defaultHeaders = headers;
-  $.ajaxSetup({ headers: headers });
 };
 
 HAL.Http.Client.prototype.getDefaultHeaders = function() {


### PR DESCRIPTION
This caused changes to custom request headers to be ignored. Calling ajaxSetup wasn't updating the headers used by the next AJAX call. The jQuery docs recommend not using ajaxSetup.