### PR TITLE
Allow credentials for CORS requests

### DIFF
--- a/js/hal/http/client.js
+++ b/js/hal/http/client.js
@@ -9,6 +9,9 @@ HAL.Http.Client.prototype.get = function(url) {
   var jqxhr = $.ajax({
     url: url,
     dataType: 'json',
+    xhrFields: {
+      withCredentials: true
+    },
     headers: this.defaultHeaders,
     success: function(resource, textStatus, jqXHR) {
       self.vent.trigger('response', {
@@ -25,6 +28,8 @@ HAL.Http.Client.prototype.get = function(url) {
 HAL.Http.Client.prototype.request = function(opts) {
   var self = this;
   opts.dataType = 'json';
+  opts.xhrFields = opts.xhrFields || {};
+  opts.xhrFields.withCredentials = opts.xhrFields.withCredentials || true;
   self.vent.trigger('location-change', { url: opts.url });
   return jqxhr = $.ajax(opts);
 };


### PR DESCRIPTION
Currently it's not possible to use HAL-Browser to request "Basic-Auth" protected contents from other domains, since the `xhrFields.withCredentials` option is missing in the `$.ajax` request.

This pull request fixes this behaviour.