### PR TITLE
protect the default headers for when custom headers are removed

### DIFF
--- a/js/hal/http/client.js
+++ b/js/hal/http/client.js
@@ -1,6 +1,7 @@
 HAL.Http.Client = function(opts) {
   this.vent = opts.vent;
   this.defaultHeaders = { 'Accept': 'application/hal+json, application/json, */*; q=0.01' };
+  this.headers = this.defaultHeaders;
 };
 
 HAL.Http.Client.prototype.get = function(url) {
@@ -12,7 +13,7 @@ HAL.Http.Client.prototype.get = function(url) {
     xhrFields: {
       withCredentials: true
     },
-    headers: this.defaultHeaders,
+    headers: this.headers,
     success: function(resource, textStatus, jqXHR) {
       self.vent.trigger('response', {
         resource: resource,
@@ -34,10 +35,10 @@ HAL.Http.Client.prototype.request = function(opts) {
   return jqxhr = $.ajax(opts);
 };
 
-HAL.Http.Client.prototype.updateDefaultHeaders = function(headers) {
-  this.defaultHeaders = headers;
+HAL.Http.Client.prototype.updateHeaders = function(headers) {
+  this.headers = headers;
 };
 
-HAL.Http.Client.prototype.getDefaultHeaders = function() {
-  return this.defaultHeaders;
+HAL.Http.Client.prototype.getHeaders = function() {
+  return this.headers;
 };

--- a/js/hal/views/non_safe_request_dialog.js
+++ b/js/hal/views/non_safe_request_dialog.js
@@ -37,7 +37,7 @@ HAL.Views.NonSafeRequestDialog = Backbone.View.extend({
   },
 
   render: function(opts) {
-    var headers = HAL.client.getDefaultHeaders(),
+    var headers = HAL.client.getHeaders(),
         headersString = '';
 
     _.each(headers, function(value, name) {

--- a/js/hal/views/request_headers.js
+++ b/js/hal/views/request_headers.js
@@ -19,7 +19,7 @@ HAL.Views.RequestHeaders = Backbone.View.extend({
   updateRequestHeaders: function(e) {
     var inputText = this.$('textarea').val() || '';
         headers = HAL.parseHeaders(inputText);
-    HAL.client.updateDefaultHeaders(headers)
+    HAL.client.updateHeaders(_.defaults(headers, HAL.client.defaultHeaders))
   },
 
   render: function() {


### PR DESCRIPTION
The custom request headers blow the defaults away. This merge request uses _.defaults to allow the custom headers to override the defaults without replacing them. Without this fix, adding a custom Accept header and then removing it does not restore the original Accept header.