### PR TITLE
Fix after-POST handling of resource URL

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -126,7 +126,7 @@
 <% _.each(headers, function(value, name) {
       %><%= _.escape(name) %>: <%
            if(HAL.isFollowableHeader(name)) {
-           %><a href="<%= HAL.normalizeUrl(_.escape(value)) %>" class="follow"><%
+           %><a href="<%= HAL.normalizeUrl(value) %>" class="follow"><%
            }
       %><%= _.escape(value)
       %><% if(HAL.isFollowableHeader(name)) {


### PR DESCRIPTION
HAL.normalizeUrl() in the response-headers-template is trying to normalize a URL after encoding it. This behavior causes forward slashes to get encoded into HTTP entities that URI.js can't read. This aptch removes the _.escape() wrapper around "value" and restores functionality.