### PR TITLE
Indepth check of curie based on rel name

### DIFF
--- a/js/hal.js
+++ b/js/hal.js
@@ -1,10 +1,6 @@
 (function() {
   var urlRegex = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
 
-  function isCurie(string) {
-    return string.split(':').length > 1;
-  };
-
   var HAL = {
     Models: {},
     Views: {},
@@ -12,7 +8,23 @@
     currentDocument: {},
     jsonIndent: 2,
     isUrl: function(str) {
-      return str.match(urlRegex) || isCurie(str);
+      return str.match(urlRegex) || HAL.isCurie(str);
+    },
+    isCurie: function(string) {
+      var isCurie = false;
+      var curieParts = string.split(':');
+      var curies = HAL.currentDocument._links.curies;
+
+      if(curieParts.length > 1 && curies) {
+
+        for (var i=0; i<curies.length; i++) {
+          if (curies[i].name == curieParts[0]) {
+            isCurie = true;
+            break;
+          }
+        }
+      }
+      return isCurie;
     },
     isFollowableHeader: function(headerName) {
       return headerName === 'Location' || headerName === 'Content-Location';

--- a/js/hal.js
+++ b/js/hal.js
@@ -44,7 +44,7 @@
       if (!HAL.currentDocument._links) {
         return rel;
       }
-      if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curies) {
+      if (!rel.match(urlRegex) && HAL.isCurie(rel) && HAL.currentDocument._links.curies) {
         var parts = rel.split(':');
         var curies = HAL.currentDocument._links.curies;
         for (var i=0; i<curies.length; i++) {
@@ -54,7 +54,7 @@
           }
         }
       }
-      else if (!rel.match(urlRegex) && isCurie(rel) && HAL.currentDocument._links.curie) {
+      else if (!rel.match(urlRegex) && HAL.isCurie(rel) && HAL.currentDocument._links.curie) {
         // Backward compatibility with <04 version of spec.
         var tmpl = uritemplate(HAL.currentDocument._links.curie.href);
         return tmpl.expand({ rel: rel.split(':')[1] });


### PR DESCRIPTION
@mikekelly  Currently if you have a hal+json payload with a curies section there are not problems.

```json
{
  "_links": {
    "curies": [
      {
        "name": "fx",
        "href": "https://api.foxycart.com/rels/{rel}",
        "templated": true
      }
    ],
    "self": {
      "href": "https://api-sandbox.foxycart.com/",
      "title": "Your API starting point."
    },
    "fx:property_helpers": {
      "href": "https://api-sandbox.foxycart.com/property_helpers",
      "title": "Various helpers used for determining valid property values."
    }
}
```

If you have an API with prefixes but have not yet added a curies section, the doc URIs fail to build and the page does not render.

This PR enables requests without a curies block but with name spaced resources to exist like below.

```json
{
  "_links": {
    "self": {
      "href": "https://api-sandbox.foxycart.com/",
      "title": "Your API starting point."
    },
    "fx:property_helpers": {
      "href": "https://api-sandbox.foxycart.com/property_helpers",
      "title": "Various helpers used for determing valid property values."
    }
}
```