### PR TITLE
fixed iframe beeing blocked due to insecure requests when using https

### DIFF
--- a/js/hal/views/documentation.js
+++ b/js/hal/views/documentation.js
@@ -2,6 +2,6 @@ HAL.Views.Documenation = Backbone.View.extend({
   className: 'documentation',
 
   render: function(url) {
-    this.$el.html('<iframe src=' + url + '></iframe>');
+    this.$el.html('<iframe src="' + url + '"></iframe>');
   }
 });


### PR DESCRIPTION
While using https lack of quoting marks around src caused iframe to make an insecure request (http) that was blocked.